### PR TITLE
fix: remove flag validation from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "validate:flags": "node scripts/validate-flags.cjs",
-    "build": "node scripts/validate-flags.cjs && tsc -b && vite build",
+    "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Problem

The deployment workflow is failing because the build script includes flag validation which requires Playwright browsers to be installed. This is redundant since the CI workflow already validates flags before code is merged to main.

**Failed deployment runs:**
- https://github.com/ravendarque/ravendarque-beyond-borders/actions/runs/18571402230
- https://github.com/ravendarque/ravendarque-beyond-borders/actions/runs/18571605525

## Solution

Remove flag validation from the build script to separate concerns:

**Before:**
```json
"build": "node scripts/validate-flags.cjs && tsc -b && vite build"
```

**After:**
```json
"build": "tsc -b && vite build"
```

## Workflow Separation

This follows the correct workflow principle:
1. **PR → CI validates**: CI workflow explicitly validates flags with Playwright installed
2. **Merge → Deploy builds**: Deployment workflow just needs to build the app (no validation)

Validation remains available for manual runs via: `pnpm validate:flags`

## Testing

- ✅ Local build with fixed script succeeds
- ✅ CI workflow still validates flags explicitly
- ⏳ Deployment workflow should succeed once merged

Closes #59
