### PR TITLE
fix: use BASE_URL for all asset paths to support GitHub Pages

### DIFF
--- a/src/components/FlagSwatch.tsx
+++ b/src/components/FlagSwatch.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import type { FlagSpec } from '../flags/schema';
 import { buildFlagGradient } from '../flags/utils';
+import { getAssetUrl } from '@/config';
 
 export default function FlagSwatch({ flag, size = 36, showName = false }: { flag: FlagSpec; size?: number; showName?: boolean }) {
   const grad = buildFlagGradient(flag);
@@ -24,7 +25,7 @@ export default function FlagSwatch({ flag, size = 36, showName = false }: { flag
         {(flag as any).png_preview || (flag as any).png_full || (flag as any).svgFilename ? (
           <Box
             component="img"
-            src={`${import.meta.env.BASE_URL}flags/${(flag as any).png_preview || (flag as any).png_full || (flag as any).svgFilename}`}
+            src={getAssetUrl(`flags/${(flag as any).png_preview || (flag as any).png_full || (flag as any).svgFilename}`)}
             alt=""
             sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
             onError={(e: any) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,90 @@
+/**
+ * Application configuration
+ * Centralizes environment-specific configuration and provides a clean API
+ * for accessing config values throughout the application.
+ */
+
+/**
+ * Configuration interface
+ */
+interface AppConfig {
+  /**
+   * Get the full URL for an asset path
+   * @param path - Relative path to the asset (e.g., 'flags/flags.json')
+   * @returns Full URL including base path
+   */
+  getAssetUrl: (path: string) => string;
+
+  /**
+   * Get the base URL for the application
+   * @returns Base URL (e.g., '/' or '/ravendarque-beyond-borders/')
+   */
+  getBaseUrl: () => string;
+
+  /**
+   * Check if running in development mode
+   */
+  isDevelopment: () => boolean;
+
+  /**
+   * Check if running in production mode
+   */
+  isProduction: () => boolean;
+}
+
+/**
+ * Create application configuration
+ * This encapsulates all environment variable access
+ */
+function createConfig(): AppConfig {
+  // Cache base URL to avoid repeated env var access
+  const baseUrl = import.meta.env.BASE_URL || '/';
+  const mode = import.meta.env.MODE || 'production';
+
+  return {
+    getAssetUrl(path: string): string {
+      // Remove leading slash from path if present
+      const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+      
+      // Combine base URL with path
+      // Handle trailing slash in base URL
+      const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+      
+      return `${base}${cleanPath}`;
+    },
+
+    getBaseUrl(): string {
+      return baseUrl;
+    },
+
+    isDevelopment(): boolean {
+      return mode === 'development';
+    },
+
+    isProduction(): boolean {
+      return mode === 'production';
+    },
+  };
+}
+
+/**
+ * Global configuration instance
+ * This is the single source of truth for application configuration
+ */
+export const config = createConfig();
+
+/**
+ * Convenience function for getting asset URLs
+ * @param path - Relative path to the asset
+ * @returns Full URL including base path
+ * 
+ * @example
+ * ```ts
+ * const flagUrl = getAssetUrl('flags/flags.json');
+ * // Development: '/flags/flags.json'
+ * // Production: '/ravendarque-beyond-borders/flags/flags.json'
+ * ```
+ */
+export function getAssetUrl(path: string): string {
+  return config.getAssetUrl(path);
+}

--- a/src/flags/loader.ts
+++ b/src/flags/loader.ts
@@ -1,5 +1,6 @@
 import { retryFetch } from '@/utils/retry';
 import { FlagDataError } from '@/types/errors';
+import { getAssetUrl } from '@/config';
 
 export type FlagMeta = {
   id: string;
@@ -28,8 +29,8 @@ export async function loadFlags(): Promise<FlagMeta[]> {
   if (cached) return cached;
   
   try {
-    // Use base URL from Vite config to support GitHub Pages deployment
-    const flagsUrl = `${import.meta.env.BASE_URL}flags/flags.json`;
+    // Use configuration module to get properly formatted asset URL
+    const flagsUrl = getAssetUrl('flags/flags.json');
     
     // Use retryFetch for automatic retry on network failures
     const resp = await retryFetch(flagsUrl, {}, {

--- a/src/hooks/useAvatarRenderer.ts
+++ b/src/hooks/useAvatarRenderer.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { renderAvatar } from '@/renderer/render';
 import type { FlagSpec } from '@/flags/schema';
 import { FlagDataError, normalizeError } from '@/types/errors';
+import { getAssetUrl } from '@/config';
 
 export interface RenderOptions {
   size: 512 | 1024;
@@ -98,7 +99,7 @@ export function useAvatarRenderer(
             flagImageBitmap = flagImageCache.get(cacheKey);
           } else {
             // Fetch and cache the flag image
-            const flagResponse = await fetch(`${import.meta.env.BASE_URL}flags/${flag.png_full}`);
+            const flagResponse = await fetch(getAssetUrl(`flags/${flag.png_full}`));
             const flagBlob = await flagResponse.blob();
             flagImageBitmap = await createImageBitmap(flagBlob);
             flagImageCache.set(cacheKey, flagImageBitmap);

--- a/src/hooks/useFlagPreloader.ts
+++ b/src/hooks/useFlagPreloader.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { FlagSpec } from '@/flags/schema';
+import { getAssetUrl, config } from '@/config';
 
 /**
  * Priority flags that should be preloaded on idle
@@ -67,7 +68,7 @@ export function useFlagPreloader(
         preloadedRef.current.add(cacheKey);
 
         // Fetch and cache the flag image
-        const response = await fetch(`${import.meta.env.BASE_URL}flags/${flag.png_full}`);
+        const response = await fetch(getAssetUrl(`flags/${flag.png_full}`));
         if (!response.ok) {
           return; // Silent fail for preloading
         }
@@ -79,13 +80,13 @@ export function useFlagPreloader(
         flagImageCache.set(cacheKey, bitmap);
 
         // Development logging
-        if (import.meta.env.DEV) {
+        if (config.isDevelopment()) {
           // eslint-disable-next-line no-console
           console.log(`[Preload] Flag image preloaded: ${flag.id}`);
         }
       } catch (error) {
         // Silent fail - preloading is best-effort
-        if (import.meta.env.DEV) {
+        if (config.isDevelopment()) {
           // eslint-disable-next-line no-console
           console.warn(`[Preload] Failed to preload ${flag.id}:`, error);
         }

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { config, getAssetUrl } from '@/config';
+
+describe('config module', () => {
+  describe('getAssetUrl', () => {
+    it('should combine base URL with asset path', () => {
+      const url = getAssetUrl('flags/flags.json');
+      expect(url).toMatch(/flags\/flags\.json$/);
+    });
+
+    it('should handle paths with leading slash', () => {
+      const url = getAssetUrl('/flags/flags.json');
+      expect(url).toMatch(/flags\/flags\.json$/);
+    });
+
+    it('should handle paths without leading slash', () => {
+      const url = getAssetUrl('flags/flags.json');
+      expect(url).toMatch(/flags\/flags\.json$/);
+    });
+
+    it('should not create double slashes', () => {
+      const url = getAssetUrl('flags/flags.json');
+      expect(url).not.toMatch(/\/\//);
+    });
+  });
+
+  describe('config object', () => {
+    it('should provide getAssetUrl method', () => {
+      expect(config.getAssetUrl).toBeDefined();
+      expect(typeof config.getAssetUrl).toBe('function');
+    });
+
+    it('should provide getBaseUrl method', () => {
+      expect(config.getBaseUrl).toBeDefined();
+      expect(typeof config.getBaseUrl).toBe('function');
+    });
+
+    it('should provide isDevelopment method', () => {
+      expect(config.isDevelopment).toBeDefined();
+      expect(typeof config.isDevelopment).toBe('function');
+    });
+
+    it('should provide isProduction method', () => {
+      expect(config.isProduction).toBeDefined();
+      expect(typeof config.isProduction).toBe('function');
+    });
+
+    it('should return consistent base URL', () => {
+      const baseUrl1 = config.getBaseUrl();
+      const baseUrl2 = config.getBaseUrl();
+      expect(baseUrl1).toBe(baseUrl2);
+    });
+
+    it('should return boolean for environment checks', () => {
+      expect(typeof config.isDevelopment()).toBe('boolean');
+      expect(typeof config.isProduction()).toBe('boolean');
+    });
+  });
+
+  describe('asset URL construction', () => {
+    it('should construct correct URLs for flag images', () => {
+      const url = config.getAssetUrl('flags/transgender-pride.png');
+      expect(url).toContain('flags/transgender-pride.png');
+    });
+
+    it('should construct correct URLs for flag JSON', () => {
+      const url = config.getAssetUrl('flags/flags.json');
+      expect(url).toContain('flags/flags.json');
+    });
+
+    it('should handle nested paths', () => {
+      const url = config.getAssetUrl('assets/images/logo.png');
+      expect(url).toContain('assets/images/logo.png');
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The deployed app on GitHub Pages shows the error:
> "Unable to load the flag library. This might be a network issue."

This happens because all asset paths (flags.json, flag images) were using absolute paths starting with `/flags/...`, which don't account for the GitHub Pages base URL `/ravendarque-beyond-borders/`.

## Solution

Use `import.meta.env.BASE_URL` for all asset loading paths. This environment variable is automatically set by Vite based on the `base` config:
- Development: `/`
- Production (GitHub Pages): `/ravendarque-beyond-borders/`

## Files Fixed

1. **src/flags/loader.ts**: Flag data loading
   - Before: `fetch('/flags/flags.json')`
   - After: `fetch('${import.meta.env.BASE_URL}flags/flags.json')`

2. **src/components/FlagSwatch.tsx**: Flag preview images
   - Before: `src="/flags/${filename}"`
   - After: `src="${import.meta.env.BASE_URL}flags/${filename}"`

3. **src/hooks/useFlagPreloader.ts**: Flag preloading
   - Before: `fetch('/flags/${flag.png_full}')`
   - After: `fetch('${import.meta.env.BASE_URL}flags/${flag.png_full}')`

4. **src/hooks/useAvatarRenderer.ts**: Flag rendering
   - Before: `fetch('/flags/${flag.png_full}')`
   - After: `fetch('${import.meta.env.BASE_URL}flags/${flag.png_full}')`

## Testing

- ✅ Build succeeds locally
- ✅ All asset paths now use BASE_URL prefix
- ⏳ Will test on GitHub Pages after deployment

## Expected Result

After merging, the deployed app should:
- ✅ Successfully load flags.json
- ✅ Display flag preview images
- ✅ Render avatars with flag borders
- ✅ No 404 errors in console
