### PR TITLE
fix: remove redundant CI runs on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, "feat/**" ]
+    branches: [ "feat/**" ]
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## Problem

CI workflow is running on every push to main, which is redundant because:
- Branch protection requires CI to pass before PR can merge
- CI already ran and passed on the PR branch
- Running CI again on main wastes CI minutes
- Creates duplicate workflow runs

## Solution

Remove `main` from the CI workflow push triggers.

**Before:**
```yaml
on:
  push:
    branches: [ main, "feat/**" ]
```

**After:**
```yaml
on:
  push:
    branches: [ "feat/**" ]
```

## Workflow After This Change

1. **Create PR** → CI runs on PR branch ✓
2. **CI passes** → PR can be merged ✓
3. **Merge to main** → Deploy workflow runs (no CI rerun) ✓

CI still runs on:
- ✅ Pull requests (validates before merge)
- ✅ Feature branches (early feedback)

CI no longer runs on:
- ❌ Main branch (already validated via PR)

## Benefits

- Eliminates redundant CI runs
- Saves CI minutes
- Cleaner workflow run history
- Follows best practice: validate once, deploy after merge
