### PR TITLE
fix: Flag images 404 in production (missing base path)

### DIFF
--- a/src/components/FlagPreview.tsx
+++ b/src/components/FlagPreview.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import type { FlagSpec } from '@/flags/schema';
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+import { getAssetUrl } from '@/config';
 
 export interface FlagPreviewProps {
   /** Flag to preview */
@@ -49,7 +50,10 @@ export const FlagPreview: React.FC<FlagPreviewProps> = ({
       ? flag.png_preview 
       : flag.png_full;
     
-    return `/flags/${filename}`;
+    if (!filename) return '';
+    
+    // Use getAssetUrl to ensure proper base path for GitHub Pages deployment
+    return getAssetUrl(`flags/${filename}`);
   };
 
   // Size in pixels - rectangular flag preview


### PR DESCRIPTION
## Problem

Flag images are returning 404 in production because FlagPreview component was using hardcoded /flags/palestine.png paths instead of including the GitHub Pages base URL.

**Production Error:**
`
404: https://ravendarque.github.io/flags/palestine.png
`

**Should be:**
`
200: https://ravendarque.github.io/ravendarque-beyond-borders/flags/palestine.png
`

## Root Cause

The getImageSrc() function in FlagPreview.tsx was returning:
`	ypescript
return /flags/\;
`

This works in development (base URL is /) but fails in production where the base URL is /ravendarque-beyond-borders/.

## Solution

- Import getAssetUrl from @/config
- Use getAssetUrl('flags/\') to properly construct URLs with base path
- Add null check for filename

## Testing

- ✅ All 324 tests passing
- ✅ Build succeeds
- ✅ Asset URL properly includes base path

## Impact

This fixes the critical bug where flag preview images don't load on step 2 in production. Users can now see flag previews and select flags properly.

## Related

This is the **second part** of the fix for flag loading issues. PR #76 fixed the schema validation, this PR fixes the image URL paths.

## Ready to Deploy

Critical hotfix - should be merged and deployed immediately.