### PR TITLE
HOTFIX: Fix React module resolution error in production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,17 +18,14 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: (id) => {
-          // Split React and React-DOM into separate chunk
+          // Keep React and MUI together in vendor chunk
+          // MUI depends on React and they must share the same React instance
           if (id.includes('node_modules/react') || 
               id.includes('node_modules/react-dom') ||
-              id.includes('node_modules/scheduler')) {
-            return 'react-vendor';
-          }
-          
-          // Split MUI into separate chunk (largest dependency)
-          if (id.includes('node_modules/@mui') || 
+              id.includes('node_modules/scheduler') ||
+              id.includes('node_modules/@mui') || 
               id.includes('node_modules/@emotion')) {
-            return 'mui-vendor';
+            return 'vendor';
           }
           
           // Split renderer utilities (canvas operations)
@@ -43,9 +40,9 @@ export default defineConfig({
         },
       },
     },
-    // Increase chunk size warning limit slightly (default is 500)
-    // We've optimized, but some chunks may still be close to the limit
-    chunkSizeWarningLimit: 600,
+    // Increase chunk size warning limit to accommodate vendor chunk
+    // Vendor chunk includes React + MUI which is larger but necessary
+    chunkSizeWarningLimit: 700,
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Critical Production Issue

**Error in production:**
```
Uncaught TypeError: can't access property 'AsyncMode', re is undefined
```

This error breaks the entire app on the deployed site.

## Root Cause

PR #82 introduced manual chunk splitting that separated React and MUI into different chunks:
- \eact-vendor\ chunk: React + React-DOM + scheduler
- \mui-vendor\ chunk: @mui + @emotion

**Problem:** MUI components depend on React and require the same React instance. When React and MUI are in separate chunks, module resolution fails and MUI cannot access React's exports.

## Solution

Keep React and MUI together in a single \endor\ chunk:
- Both libraries must share the same React instance
- Module dependencies are properly maintained
- No module resolution errors

## Changes Made

**vite.config.ts:**
- Combined React and MUI into single \endor\ chunk
- Increased \chunkSizeWarningLimit\ to 700KB to accommodate vendor chunk
- Maintained separate chunks for renderer and flags

## Bundle Analysis

**New Build Output:**
\\\
dist/assets/vendor.js     451.34 KB │ gzip: 145.56 KB  (React + MUI)
dist/assets/index.js       45.35 KB │ gzip:  14.63 KB  (app code)
dist/assets/renderer.js     9.46 KB │ gzip:   3.59 KB  (canvas)
dist/assets/flags.js        8.99 KB │ gzip:   1.45 KB  (flags)
\\\

**Previous (broken) Build:**
\\\
dist/assets/react-vendor.js  166.91 KB │ gzip:  54.22 KB
dist/assets/mui-vendor.js    282.51 KB │ gzip:  90.64 KB
\\\

## Trade-offs

**Pros:**
- ✅ App works correctly in production
- ✅ Proper React instance sharing
- ✅ No module resolution errors
- ✅ Still benefits from code splitting (renderer, flags separate)

**Cons:**
- ❌ Slightly larger initial vendor chunk (451KB vs 283KB for MUI alone)
- ℹ️ BUT: Users download same total size, just in one file instead of two
- ℹ️ Better caching: vendor changes less frequently than app code

## Testing

✅ All 324 tests passing
✅ Build successful  
✅ TypeScript compilation successful
✅ Tested locally - app loads correctly

## Priority

🚨 **CRITICAL** - This is a production-breaking hotfix that must be merged immediately.

The app is currently broken on the live site and users cannot use it.