### PR TITLE
fix(scripts): Correct lib/ import paths in commands/ subdirectory

### DIFF
--- a/.github/scripts/commands/create-pr.ps1
+++ b/.github/scripts/commands/create-pr.ps1
@@ -47,8 +47,8 @@ param(
 )
 
 # Import utilities
-. "$PSScriptRoot\lib\config.ps1"
-. "$PSScriptRoot\lib\github-utils.ps1"
+. "$PSScriptRoot\..\lib\config.ps1"
+. "$PSScriptRoot\..\lib\github-utils.ps1"
 
 # Verify gh CLI
 if (-not (Test-GitHubCLI)) {

--- a/.github/scripts/commands/create-tracked-issue.ps1
+++ b/.github/scripts/commands/create-tracked-issue.ps1
@@ -29,8 +29,8 @@ param(
 )
 
 # Import utilities
-. "$PSScriptRoot\lib\config.ps1"
-. "$PSScriptRoot\lib\github-utils.ps1"
+. "$PSScriptRoot\..\lib\config.ps1"
+. "$PSScriptRoot\..\lib\github-utils.ps1"
 
 # Verify GitHub CLI
 if (-not (Test-GitHubCLI)) {

--- a/.github/scripts/commands/list-issues.ps1
+++ b/.github/scripts/commands/list-issues.ps1
@@ -30,8 +30,8 @@ param(
 )
 
 # Import utilities
-. "$PSScriptRoot\lib\config.ps1"
-. "$PSScriptRoot\lib\github-utils.ps1"
+. "$PSScriptRoot\..\lib\config.ps1"
+. "$PSScriptRoot\..\lib\github-utils.ps1"
 
 # Verify GitHub CLI
 if (-not (Test-GitHubCLI)) {

--- a/.github/scripts/commands/update-issue.ps1
+++ b/.github/scripts/commands/update-issue.ps1
@@ -25,8 +25,8 @@ param(
 )
 
 # Import utilities
-. "$PSScriptRoot\lib\config.ps1"
-. "$PSScriptRoot\lib\github-utils.ps1"
+. "$PSScriptRoot\..\lib\config.ps1"
+. "$PSScriptRoot\..\lib\github-utils.ps1"
 
 # Verify at least one field to update
 if (-not $Status -and -not $Priority -and -not $Size) {


### PR DESCRIPTION
## Overview

Critical hotfix for the script reorganization in PR #91. The commands moved to `commands/` subdirectory but their imports still referenced `lib/` as if they were in the parent directory.

## Problem

After PR #91, running any script command would fail with:
```
The term 'D:\...\commands\lib\config.ps1' is not recognized
```

The scripts in `commands/` were using:
```powershell
. "$PSScriptRoot\lib\config.ps1"
```

But since they're now in `commands/`, they need to go up one level:
```powershell
. "$PSScriptRoot\..\lib\config.ps1"
```

## Changes

Fixed import paths in all command scripts:
- `commands/create-pr.ps1`
- `commands/create-tracked-issue.ps1`
- `commands/list-issues.ps1`
- `commands/update-issue.ps1`

## Testing

✅ Verified `github-helper.ps1` works correctly with all commands
✅ Successfully created PR #92 using the fixed scripts

## Impact

Without this fix, the entire script system from PR #91 is non-functional. This should be merged immediately.
