### PR TITLE
fix(ci): add missing permissions to fetch-flags workflow

### DIFF
--- a/.github/workflows/fetch-flags.yml
+++ b/.github/workflows/fetch-flags.yml
@@ -9,6 +9,10 @@ on:
       - 'data/flag-data.yaml'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fetch-and-validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Fixes the `fetch-flags.yml` workflow failing to create pull requests due to missing permissions configuration.

## Problem
The workflow was failing with git exit code 128 in the "Create pull request with updated flags" step. The `peter-evans/create-pull-request@v5` action requires write permissions to create branches and PRs, but the workflow was missing a `permissions` block.

## Solution
Added `permissions` block with:
- `contents: write` - Required to create branches and commit changes
- `pull-requests: write` - Required to create pull requests

This follows the same pattern as other workflows like `deploy-pr.yml`.

## Changes
- Added `permissions` block to `.github/workflows/fetch-flags.yml`

## Testing
- ✅ Workflow file syntax validated
- ✅ Follows same pattern as existing workflows
- Will be verified on next workflow run

## Related
Fixes #133


Closes #133