### PR TITLE
fix(versioning): revert to standard GitVersion PR naming

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -19,13 +19,3 @@ branches:
     regex: ^(release|hotfix)/
     mode: ContinuousDelivery
     source-branches: ['main']
-  pull-request:
-    regex: ^(pull|pull\-requests|pr)[/-]
-    mode: ContinuousDelivery
-    tag: beta
-    increment: Inherit
-    prevent-increment-of-merged-branch-version: true
-    track-merge-target: false
-    tracks-release-branches: false
-    is-release-branch: false
-    source-branches: []


### PR DESCRIPTION
## Summary

Reverts the attempt to customize the PR prerelease label from "PullRequest" to "beta". The `tag` property is not supported in GitVersion 5.12.0 branch configurations, causing serialization errors.

## Changes

- Removed `pull-request` branch configuration from `GitVersion.yml`
- GitVersion will now use its default behavior for PR branches

## Impact

PR versions will use the standard GitVersion format: `1.1.0-PullRequest0137.55` instead of the attempted `1.1.0-beta.55`.

## Related

Fixes the deployment workflow failure in PR #137.
