### PR TITLE
fix(mobile): Prevent Firefox Android page zoom on pinch-to-zoom in

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -360,6 +360,9 @@ label.choose-circle:hover {
 
 .choose-circle.has-image {
   border: none;
+  /* Prevent ALL browser touch gestures - we handle panning and pinch-to-zoom ourselves */
+  /* This prevents Firefox Android from intercepting pinch gestures */
+  touch-action: none;
 }
 
 .choose-circle.has-image:hover {


### PR DESCRIPTION
## Problem
Firefox for Android was intercepting pinch-to-zoom gestures before React's synthetic events could prevent them, causing the browser to zoom the entire page instead of zooming the profile picture when pinching to zoom in. Pinch-to-zoom out was already working correctly.

## Solution
- **Native event listeners in capture phase**: Added native `touchstart` and `touchmove` listeners with `capture: true` and `passive: false` to intercept two-touch pinch gestures before the browser processes them. This allows `preventDefault()` to properly block browser zoom in Firefox Android.

- **CSS `touch-action: none`**: Added to `.choose-circle.has-image` to prevent all browser touch gestures, since we handle panning and pinch-to-zoom ourselves.

- **Hybrid approach**: 
  - Native listeners handle two-touch pinch (with `preventDefault()`)
  - React synthetic events handle single-touch drag (for compatibility with existing drag handler)

## Testing
Tested on Firefox Android - pinch-to-zoom in now zooms the image instead of the page. Pinch-to-zoom out continues to work as before, and single-touch drag remains unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes mobile pinch behavior so the image zooms instead of the page on Firefox Android.
> 
> - Use native `touchstart`/`touchmove` listeners (`capture: true`, `passive: false`) to intercept two-finger pinch, `preventDefault()`, calculate distance ratio, and update `zoom`
> - Keep single-touch drag on React handlers; adjust `combinedTouchStart`/`handleTouchMove` to ignore two-touch events handled natively
> - Add `touch-action: none` to `.choose-circle.has-image` to disable browser touch gestures
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a280c842de96aa7bcad073ea57676002571b7cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->