### PR TITLE
fix(deploy): Remove build metadata suffix from footer version

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           NODE_ENV: production
           BASE_URL: /
-          VERSION: ${{ steps.gitversion.outputs.fullSemVer }}
+          VERSION: ${{ steps.gitversion.outputs.semVer }}
 
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
The version number in the footer was showing `v1.1.3+2` instead of `v1.1.3`, which doesn't match the release tag format.

## Solution
Changed the `VERSION` environment variable in `deploy-main.yml` from `fullSemVer` (which includes build metadata like `+2`) to `semVer` (clean semantic version).

## Changes
- Updated `.github/workflows/deploy-main.yml` line 64 to use `semVer` instead of `fullSemVer`

## Result
Footer now displays `v1.1.3` instead of `v1.1.3+2`, matching the release tag format.

## Testing
- ✅ Linting passed
- ✅ Pre-push validation checks passed
- Will be verified on next production deployment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the production deploy workflow to use a clean semantic version for the build.
> 
> - In `.github/workflows/deploy-main.yml`, `VERSION` now uses `steps.gitversion.outputs.semVer` (was `fullSemVer`) to drop build metadata from the app’s displayed version
> - No other deployment steps changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cde241fd5a1a69c76dd49166ae5fa39cc70e4b79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->