### PR TITLE
fix(offset): Update defaultOffset when flag changes on step 2

### DIFF
--- a/src/pages/AppStepWorkflow.tsx
+++ b/src/pages/AppStepWorkflow.tsx
@@ -207,9 +207,9 @@ export function AppStepWorkflow() {
       // Set default when:
       // 1. Switching to cutout mode
       // 2. Flag changes while on step 3 (even if already in cutout mode)
-      // 3. Entering step 3 with cutout mode already selected (to update offset for current flag)
+      // 3. First time entering step 3 with cutout mode already selected (to set initial offset)
       // 4. Flag changed on step 2 and we're now entering step 3 (flagChangedSinceLastStep3)
-      if (switchedToCutout || (flagChanged && currentStep === 3) || enteredStep3 || flagChangedSinceLastStep3) {
+      if (switchedToCutout || (flagChanged && currentStep === 3) || (enteredStep3 && flagIdOnStep3Ref.current === null) || flagChangedSinceLastStep3) {
         if (defaultOffset !== undefined) {
           // Use the percentage directly - no conversion needed
           setFlagOffsetPct(defaultOffset);


### PR DESCRIPTION
## Summary
Fixes bug where `defaultOffset` is not updated when changing flags on step 2, and preserves user-adjusted offset values when navigating between steps.

## Changes
- Added `flagIdOnStep3Ref` to track the flag ID when we were last on step 3
- Added `prevStepRef` to detect when entering step 3
- Always update refs (not just when on step 3) to track flag changes on step 2
- Check for flag changes before updating `flagIdOnStep3Ref` to detect changes correctly
- **Only reset offset on first entry to step 3** - preserves user adjustments when navigating step 3 → step 2 → step 3
- Offset now updates correctly when changing flags on step 2 and entering step 3

## Testing
1. Select disability pride flag on step 2 (defaultOffset: -5)
2. Move to step 3 and select cutout mode (offset correctly set to -5)
3. Adjust offset to a custom value (e.g., -10)
4. Move back to step 2
5. Move back to step 3
6. **Expected:** Offset should remain at -10 (user adjustment preserved) ✅
7. **Before fix:** Offset was reset to -5 ❌

8. Move back to step 2
9. Select pride progress flag (defaultOffset: -25)
10. Move to step 3
11. **Expected:** Offset should be -25 (new flag's default) ✅
12. **Before fix:** Offset remained at -5 ❌

## Related Issue
Closes #145