### PR TITLE
fix: step 1/3 controls width and gap (fixes #150)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1482,7 +1482,8 @@ label.choose-circle.has-image.is-dragging,
 /* Presentation Mode Toggle Buttons */
 .presentation-controls {
   width: 100%;
-  max-width: 320px;
+  max-width: min(320px, 100%);
+  min-width: 0;
   display: flex;
   justify-content: center;
 }
@@ -1567,15 +1568,20 @@ label.choose-circle.has-image.is-dragging,
 
 .adjust-controls {
   width: 100%;
-  max-width: 320px;
+  max-width: min(320px, 100%);
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  box-sizing: border-box;
 }
 
 .step1-controls {
   width: 100%;
-  max-width: 320px;
+  max-width: min(320px, 100%);
+  min-width: 0;
+  padding-inline: 16px; /* gap from display edge */
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -1608,6 +1614,7 @@ label.choose-circle.has-image.is-dragging,
   flex-direction: column;
   gap: 8px;
   width: 100%;
+  min-width: 0;
 }
 
 .slider-labels-row {
@@ -1643,6 +1650,7 @@ label.choose-circle.has-image.is-dragging,
   align-items: center;
   gap: 8px;
   width: 100%;
+  min-width: 0;
 }
 
 .slider-icon {
@@ -1660,6 +1668,7 @@ label.choose-circle.has-image.is-dragging,
   user-select: none;
   touch-action: none;
   flex: 1;
+  min-width: 0;
   height: 20px;
 }
 


### PR DESCRIPTION
## Summary

Fixes #150 — profile image adjustment controls too wide / touching the edge on Firefox Android (and narrow viewports).

## Changes

- **Constrain control width:** `.adjust-controls`, `.presentation-controls`, `.step1-controls` use `max-width: min(320px, 100%)` and `min-width: 0` so they never overflow the parent and can shrink on narrow viewports.
- **Step 1 gap:** `padding-inline: 16px` on `.step1-controls` only so step 1 sliders have a gap from the display edge.
- **Step 3:** No extra padding on step 3 controls (canvas padding only) to avoid double padding.
- **Sliders:** `min-width: 0` on `.slider-container`, `.slider-with-icons`, `.slider-root` so the flex row can shrink.
- **Box model:** `box-sizing: border-box` on control blocks.

## Testing

- [ ] Step 1: Move/zoom sliders have visible gap from edges; no horizontal overflow on narrow viewport.
- [ ] Step 3: Thickness/offset sliders and presentation toggles don't touch edges; no double padding.
- [ ] Firefox Android (or narrow viewport): controls stay within display area.