### PR TITLE
Add default border thickness config setting

### DIFF
--- a/.github/scripts/local-ci.ps1
+++ b/.github/scripts/local-ci.ps1
@@ -117,9 +117,59 @@ function Test-CommandExists {
 # Refresh PATH at start to pick up newly installed tools
 Refresh-EnvironmentPath
 
-# 1. Security audit
-Write-Host "1️⃣  Running security audit..." -ForegroundColor White
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Detect production code changes first (used to decide whether to run build checks)
+$stagedFiles = git diff --cached --name-only 2>&1
+if (-not $stagedFiles) {
+    $remoteBranch = git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>&1
+    if ($LASTEXITCODE -eq 0 -and $remoteBranch -and $remoteBranch -ne '') {
+        $stagedFiles = git diff --name-only --diff-filter=ACM "$remoteBranch..HEAD" 2>&1
+    }
+}
+$prodPattern = "^(src/|public/|index.html|vite.config.ts|tsconfig.json|package.json|pnpm-lock.yaml|playwright.config.ts|scripts/|.github/scripts/)"
+$prodFilesChanged = $stagedFiles | Where-Object { $_ -match $prodPattern }
+
+# 1-4: Run lint, format, build, tests FIRST (most common failures = fastest feedback)
+if ($prodFilesChanged -and -not $SkipBuild) {
+    Write-Host "1️⃣  Linting code..." -ForegroundColor White
+    $exitCode = 0
+    pnpm run lint 2>&1 | Out-Null
+    $exitCode = $LASTEXITCODE
+    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Linting passed" } else { "Linting failed" })
+    Write-Host ""
+
+    Write-Host "2️⃣  Checking code format (Prettier)..." -ForegroundColor White
+    $exitCode = 0
+    pnpm run format:check 2>&1 | Out-Null
+    $exitCode = $LASTEXITCODE
+    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Format check passed" } else { "Format check failed (run: pnpm run format)" })
+    Write-Host ""
+
+    Write-Host "3️⃣  Type checking and building..." -ForegroundColor White
+    $exitCode = 0
+    pnpm run build 2>&1 | Out-Null
+    $exitCode = $LASTEXITCODE
+    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Build passed" } else { "Build failed" })
+    Write-Host ""
+
+    Write-Host "4️⃣  Running tests..." -ForegroundColor White
+    $exitCode = 0
+    pnpm test -- --run 2>&1 | Out-Null
+    $exitCode = $LASTEXITCODE
+    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Tests passed" } else { "Tests failed" })
+    Write-Host ""
+} else {
+    if ($SkipBuild) {
+        Write-Host "1️⃣–4️⃣  Skipping build checks (--SkipBuild flag)" -ForegroundColor Yellow
+    } else {
+        Write-Host "1️⃣–4️⃣  No production code changes - skipping build checks" -ForegroundColor Green
+    }
+    Write-Host ""
+}
+
+# 5-12: Other checks (less common failures, run after lint/format/build/tests)
+Write-Host "5️⃣  Running security audit..." -ForegroundColor White
 $exitCode = 0
 try {
     & pwsh -File "$scriptDir/check-security.ps1" 2>&1 | Out-Host
@@ -132,8 +182,7 @@ if ($exitCode -ne 0) {
 }
 Write-Host ""
 
-# 2. Markdown linting
-Write-Host "2️⃣  Linting Markdown files..." -ForegroundColor White
+Write-Host "6️⃣  Linting Markdown files..." -ForegroundColor White
 $exitCode = 0
 try {
     & pwsh -File "$scriptDir/check-markdown.ps1" 2>&1 | Out-Host
@@ -146,8 +195,7 @@ if ($exitCode -ne 0) {
 }
 Write-Host ""
 
-# 3. YAML linting
-Write-Host "3️⃣  Linting YAML files..." -ForegroundColor White
+Write-Host "7️⃣  Linting YAML files..." -ForegroundColor White
 $exitCode = 0
 try {
     & pwsh -File "$scriptDir/check-yaml.ps1" 2>&1 | Out-Host
@@ -160,9 +208,7 @@ if ($exitCode -ne 0) {
 }
 Write-Host ""
 
-# 4. Check for TODO/FIXME
-Write-Host "4️⃣  Checking for TODO/FIXME comments..." -ForegroundColor White
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Write-Host "8️⃣  Checking for TODO/FIXME comments..." -ForegroundColor White
 try {
     & pwsh -File "$scriptDir/check-todo-fixme.ps1" | Out-Host
 } catch {
@@ -170,8 +216,7 @@ try {
 }
 Write-Host ""
 
-# 5. Validate file permissions
-Write-Host "5️⃣  Validating file permissions..." -ForegroundColor White
+Write-Host "9️⃣  Validating file permissions..." -ForegroundColor White
 try {
     & pwsh -File "$scriptDir/check-file-permissions.ps1"
     if ($LASTEXITCODE -ne 0) {
@@ -182,8 +227,7 @@ try {
 }
 Write-Host ""
 
-# 6. Check for large files
-Write-Host "6️⃣  Checking for large files (>1MB)..." -ForegroundColor White
+Write-Host "🔟 Checking for large files (>1MB)..." -ForegroundColor White
 try {
     & pwsh -File "$scriptDir/check-large-files.ps1" | Out-Host
 } catch {
@@ -191,9 +235,7 @@ try {
 }
 Write-Host ""
 
-# 7. Privacy check - detect tracking, Google Fonts, etc.
-Write-Host "7️⃣  Checking for privacy concerns..." -ForegroundColor White
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Write-Host "1️⃣1️⃣  Checking for privacy concerns..." -ForegroundColor White
 $privacyExit = 0
 try {
     & pwsh -File "$scriptDir/check-privacy.ps1"
@@ -206,8 +248,7 @@ if ($privacyExit -ne 0) {
 }
 Write-Host ""
 
-# 8. Check for stale references and missing files
-Write-Host "8️⃣  Checking for stale references..." -ForegroundColor White
+Write-Host "1️⃣2️⃣  Checking for stale references..." -ForegroundColor White
 try {
     & pwsh -File "$scriptDir/check-stale-references.ps1"
     if ($LASTEXITCODE -ne 0) {
@@ -217,64 +258,6 @@ try {
     $script:Errors++
 }
 Write-Host ""
-
-# 9. Check if production code changed and run build checks
-Write-Host "9️⃣  Checking if production code changed..." -ForegroundColor White
-# Get staged files first (for commit-time checks)
-$stagedFiles = git diff --cached --name-only 2>&1
-# If no staged files, check files being pushed (pre-push hook context)
-if (-not $stagedFiles) {
-    $currentBranch = git rev-parse --abbrev-ref HEAD 2>&1
-    $remoteBranch = git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>&1
-    if ($LASTEXITCODE -eq 0 -and $remoteBranch -and $remoteBranch -ne '') {
-        $stagedFiles = git diff --name-only --diff-filter=ACM "$remoteBranch..HEAD" 2>&1
-    }
-}
-$prodPattern = "^(src/|public/|index.html|vite.config.ts|tsconfig.json|package.json|pnpm-lock.yaml|playwright.config.ts|scripts/|.github/scripts/)"
-$prodFilesChanged = $stagedFiles | Where-Object { $_ -match $prodPattern }
-
-if ($prodFilesChanged -and -not $SkipBuild) {
-    Write-Host "Production code changes detected. Running build checks...`n" -ForegroundColor Yellow
-    
-    # Lint
-    Write-Host "  📝 Linting code..." -ForegroundColor White
-    $exitCode = 0
-    pnpm run lint 2>&1 | Out-Null
-    $exitCode = $LASTEXITCODE
-    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Linting passed" } else { "Linting failed" })
-    Write-Host ""
-
-    # Format (Prettier)
-    Write-Host "  ✨ Checking code format (Prettier)..." -ForegroundColor White
-    $exitCode = 0
-    pnpm run format:check 2>&1 | Out-Null
-    $exitCode = $LASTEXITCODE
-    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Format check passed" } else { "Format check failed (run: pnpm run format)" })
-    Write-Host ""
-    
-    # Build
-    Write-Host "  🏗️  Type checking and building..." -ForegroundColor White
-    $exitCode = 0
-    pnpm run build 2>&1 | Out-Null
-    $exitCode = $LASTEXITCODE
-    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Build passed" } else { "Build failed" })
-    Write-Host ""
-    
-    # Tests
-    Write-Host "  🧪 Running tests..." -ForegroundColor White
-    $exitCode = 0
-    pnpm test -- --run 2>&1 | Out-Null
-    $exitCode = $LASTEXITCODE
-    Print-Status ($exitCode -eq 0) $(if ($exitCode -eq 0) { "Tests passed" } else { "Tests failed" })
-    Write-Host ""
-} else {
-    if ($SkipBuild) {
-        Write-Host "Skipping build checks (--SkipBuild flag)" -ForegroundColor Yellow
-    } else {
-        Write-Host "✅ No production code changes - skipping build checks" -ForegroundColor Green
-    }
-    Write-Host ""
-}
 
 # Summary
 Write-Host "========================================" -ForegroundColor Cyan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
               - '.github/scripts/**'
               - '.github/workflows/**'
 
-  # Lightweight validation - runs when production code changes
+  # Lightweight validation (security, markdown, yaml, etc.) - runs in parallel with build-and-test
   validate:
     needs: check-changes
     if: needs.check-changes.outputs.production-code == 'true'
@@ -113,9 +113,9 @@ jobs:
       - name: Check stale references
         run: pwsh .github/scripts/check-stale-references.ps1
 
-  # Full build and test suite - runs after validation passes
+  # Lint, format, build, unit tests - runs first for fastest feedback (most common failures)
   build-and-test:
-    needs: [check-changes, validate]
+    needs: check-changes
     if: needs.check-changes.outputs.production-code == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -141,6 +141,7 @@ jobs:
       - name: Validate flag SVGs
         run: node scripts/validate-flags.js
 
+      # Order: lint → format → build → tests (most common failures first)
       - name: Lint code
         run: pnpm run lint
 
@@ -161,9 +162,9 @@ jobs:
           path: coverage
           if-no-files-found: ignore
 
-  # E2E tests (full suite, all browsers) - full test pyramid on PR
+  # E2E tests (full suite, all browsers) - after unit tests pass
   e2e:
-    needs: [check-changes, validate]
+    needs: [check-changes, build-and-test]
     if: needs.check-changes.outputs.production-code == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/data/flag-data.schema.json
+++ b/data/flag-data.schema.json
@@ -90,6 +90,12 @@
                       "minimum": -50,
                       "maximum": 50,
                       "description": "The default value of the offset slider. -50 (left edge of border touches left edge of flag), 0 (centre, no offset), 50 (right edge of border touches right edge of flag)"
+                    },
+                    "defaultBorderThickness": {
+                      "type": "integer",
+                      "minimum": 5,
+                      "maximum": 15,
+                      "description": "Default border thickness percentage for cutout mode (5-15). If omitted, step 3 uses the app default."
                     }
                   },
                   "additionalProperties": false

--- a/data/flag-data.yaml
+++ b/data/flag-data.yaml
@@ -380,7 +380,7 @@ categories:
         cutoutMode:
           offsetEnabled: true
           defaultOffset: 0
-          #defaultBorderThickness: 13 # TODO: enable this functionality
+          defaultBorderThickness: 13
 
   - categoryName: 'Stateless People'
     displayOrder: 6

--- a/scripts/lib/typescript-generator.js
+++ b/scripts/lib/typescript-generator.js
@@ -101,6 +101,13 @@ export function generateTypeScriptSource(manifest) {
         lines.push('      cutout: {');
         lines.push(`        offsetEnabled: ${entry.cutoutMode.offsetEnabled},`);
         lines.push(`        defaultOffset: ${entry.cutoutMode.defaultOffset},`);
+        if (
+          entry.cutoutMode.defaultBorderThickness != null &&
+          entry.cutoutMode.defaultBorderThickness >= 5 &&
+          entry.cutoutMode.defaultBorderThickness <= 15
+        ) {
+          lines.push(`        defaultBorderThickness: ${entry.cutoutMode.defaultBorderThickness},`);
+        }
         lines.push('      },');
       }
 

--- a/src/flags/flags.ts
+++ b/src/flags/flags.ts
@@ -883,6 +883,7 @@ export const flags: FlagSpec[] = [
       cutout: {
         offsetEnabled: true,
         defaultOffset: 0,
+        defaultBorderThickness: 13,
       },
     },
   },

--- a/src/flags/schema.ts
+++ b/src/flags/schema.ts
@@ -50,6 +50,7 @@ export const FlagSpec = z.object({
         .object({
           offsetEnabled: z.boolean(),
           defaultOffset: z.number().min(-50).max(50),
+          defaultBorderThickness: z.number().min(5).max(15).optional(),
         })
         .optional(),
     })

--- a/src/hooks/useStepTransitions.ts
+++ b/src/hooks/useStepTransitions.ts
@@ -27,7 +27,11 @@ export interface UseStepTransitionsOptions {
   /** Callback to update flag offset */
   onFlagOffsetChange: (offset: number) => void;
   /** Callback to update step 3 configuration for flag */
-  onUpdateStep3ForFlag: (flagId: string | null, defaultOffset?: number) => void;
+  onUpdateStep3ForFlag: (
+    flagId: string | null,
+    defaultOffset?: number,
+    defaultThickness?: number,
+  ) => void;
 }
 
 /**
@@ -102,10 +106,10 @@ export function useStepTransitions(options: UseStepTransitionsOptions): void {
     return () => window.removeEventListener('resize', updateCircleSize);
   }, [step1.imageUrl, onCircleSizeChange]); // Re-run when image changes to ensure element exists
 
-  // Handle flag offset reset logic (consolidated - handles both flag changes and mode switches)
+  // Handle flag offset and thickness reset logic (consolidated - handles both flag changes and mode switches)
   useEffect(() => {
-    // Use business logic to determine if offset should be reset
-    const { shouldReset, defaultOffset } = shouldResetFlagOffset(
+    // Use business logic to determine if offset/thickness should be reset
+    const { shouldReset, defaultOffset, defaultThickness } = shouldResetFlagOffset(
       currentStep,
       step3.presentation,
       step2.flagId,
@@ -115,7 +119,7 @@ export function useStepTransitions(options: UseStepTransitionsOptions): void {
 
     if (shouldReset) {
       onFlagOffsetChange(defaultOffset ?? 0);
-      onUpdateStep3ForFlag(step2.flagId, defaultOffset);
+      onUpdateStep3ForFlag(step2.flagId, defaultOffset, defaultThickness);
     }
   }, [
     currentStep,

--- a/src/hooks/useStepTransitions.ts
+++ b/src/hooks/useStepTransitions.ts
@@ -18,6 +18,8 @@ import { shouldResetFlagOffset } from './workflowLogic';
 export interface UseStepTransitionsOptions {
   /** Current workflow state */
   state: WorkflowState;
+  /** Currently displayed step (from navigation) - use this for step-3 logic to avoid races when going back */
+  displayedStep: 1 | 2 | 3;
   /** Selected flag (memoized) */
   selectedFlag: FlagSpec | null;
   /** Callback to update image dimensions */
@@ -43,6 +45,7 @@ export interface UseStepTransitionsOptions {
 export function useStepTransitions(options: UseStepTransitionsOptions): void {
   const {
     state,
+    displayedStep,
     selectedFlag,
     onImageDimensionsChange,
     onCircleSizeChange,
@@ -50,7 +53,7 @@ export function useStepTransitions(options: UseStepTransitionsOptions): void {
     onUpdateStep3ForFlag,
   } = options;
 
-  const { step1, step2, step3, currentStep } = state;
+  const { step1, step2, step3 } = state;
 
   // Detect image dimensions when image URL changes
   useEffect(() => {
@@ -107,10 +110,10 @@ export function useStepTransitions(options: UseStepTransitionsOptions): void {
   }, [step1.imageUrl, onCircleSizeChange]); // Re-run when image changes to ensure element exists
 
   // Handle flag offset and thickness reset logic (consolidated - handles both flag changes and mode switches)
+  // Use displayedStep (from navigation) so we never run step-3 logic when user has clicked Back and is viewing step 2
   useEffect(() => {
-    // Use business logic to determine if offset/thickness should be reset
     const { shouldReset, defaultOffset, defaultThickness } = shouldResetFlagOffset(
-      currentStep,
+      displayedStep,
       step3.presentation,
       step2.flagId,
       step3.configuredForFlagId,
@@ -122,7 +125,7 @@ export function useStepTransitions(options: UseStepTransitionsOptions): void {
       onUpdateStep3ForFlag(step2.flagId, defaultOffset, defaultThickness);
     }
   }, [
-    currentStep,
+    displayedStep,
     step2.flagId,
     step3.presentation,
     step3.configuredForFlagId,

--- a/src/hooks/useWorkflowState.ts
+++ b/src/hooks/useWorkflowState.ts
@@ -33,7 +33,7 @@ export type WorkflowAction =
   | { type: 'RESET_STEP2' }
   | { type: 'RESET_STEP3' }
   | { type: 'RESET_ALL' }
-  | { type: 'UPDATE_STEP3_FOR_FLAG'; flagId: string | null; defaultOffset?: number };
+  | { type: 'UPDATE_STEP3_FOR_FLAG'; flagId: string | null; defaultOffset?: number; defaultThickness?: number };
 
 /**
  * Reducer for workflow state
@@ -197,6 +197,8 @@ export function workflowReducer(state: WorkflowState, action: WorkflowAction): W
           ...state.step3,
           configuredForFlagId: action.flagId,
           flagOffsetPct: action.defaultOffset ?? state.step3.flagOffsetPct,
+          thickness:
+            action.defaultThickness != null ? action.defaultThickness : state.step3.thickness,
         },
       };
 
@@ -358,9 +360,12 @@ export function useWorkflowState() {
     }
   }, []);
 
-  const updateStep3ForFlag = useCallback((flagId: string | null, defaultOffset?: number) => {
-    dispatch({ type: 'UPDATE_STEP3_FOR_FLAG', flagId, defaultOffset });
-  }, []);
+  const updateStep3ForFlag = useCallback(
+    (flagId: string | null, defaultOffset?: number, defaultThickness?: number) => {
+      dispatch({ type: 'UPDATE_STEP3_FOR_FLAG', flagId, defaultOffset, defaultThickness });
+    },
+    [],
+  );
 
   return {
     state,

--- a/src/hooks/useWorkflowState.ts
+++ b/src/hooks/useWorkflowState.ts
@@ -33,7 +33,12 @@ export type WorkflowAction =
   | { type: 'RESET_STEP2' }
   | { type: 'RESET_STEP3' }
   | { type: 'RESET_ALL' }
-  | { type: 'UPDATE_STEP3_FOR_FLAG'; flagId: string | null; defaultOffset?: number; defaultThickness?: number };
+  | {
+      type: 'UPDATE_STEP3_FOR_FLAG';
+      flagId: string | null;
+      defaultOffset?: number;
+      defaultThickness?: number;
+    };
 
 /**
  * Reducer for workflow state

--- a/src/hooks/workflowLogic.ts
+++ b/src/hooks/workflowLogic.ts
@@ -21,13 +21,14 @@ export function shouldResetFlagOffset(
   flagId: string | null,
   configuredForFlagId: string | null,
   selectedFlag: FlagSpec | null,
-): { shouldReset: boolean; defaultOffset: number | undefined } {
+): { shouldReset: boolean; defaultOffset: number | undefined; defaultThickness: number | undefined } {
   // Only handle in Step 3 with cutout mode
   if (currentStep !== 3 || presentation !== 'cutout') {
-    return { shouldReset: false, defaultOffset: undefined };
+    return { shouldReset: false, defaultOffset: undefined, defaultThickness: undefined };
   }
 
   const defaultOffset = selectedFlag?.modes?.cutout?.defaultOffset;
+  const defaultThickness = selectedFlag?.modes?.cutout?.defaultBorderThickness;
   const flagChanged = configuredForFlagId !== null && configuredForFlagId !== flagId;
   const firstTimeConfiguring = configuredForFlagId === null;
 
@@ -36,8 +37,9 @@ export function shouldResetFlagOffset(
     return {
       shouldReset: true,
       defaultOffset: defaultOffset ?? 0, // Default to 0 if flag has no cutout config
+      defaultThickness,
     };
   }
 
-  return { shouldReset: false, defaultOffset: undefined };
+  return { shouldReset: false, defaultOffset: undefined, defaultThickness: undefined };
 }

--- a/src/hooks/workflowLogic.ts
+++ b/src/hooks/workflowLogic.ts
@@ -8,12 +8,14 @@
 import type { FlagSpec } from '@/flags/schema';
 
 /**
- * Determine if flag offset should be reset
+ * Determine if step 3 should be synced to the current flag (offset, thickness, configuredForFlagId).
  *
- * Business rule: Reset offset when:
- * - Flag changes in cutout mode
- * - Switching to cutout mode for the first time for a flag
- * - First time configuring a flag in cutout mode
+ * Business rule: Sync when we're actually on step 3 and:
+ * - Flag changed (user selected a different flag), or
+ * - First time configuring (configuredForFlagId is null, e.g. after navigating back then forward).
+ *
+ * Uses cutout defaults when in cutout mode; otherwise keeps current thickness/offset so we don't
+ * overwrite user choices when switching flags in ring/segment mode.
  */
 export function shouldResetFlagOffset(
   currentStep: number,
@@ -21,25 +23,30 @@ export function shouldResetFlagOffset(
   flagId: string | null,
   configuredForFlagId: string | null,
   selectedFlag: FlagSpec | null,
-): { shouldReset: boolean; defaultOffset: number | undefined; defaultThickness: number | undefined } {
-  // Only handle in Step 3 with cutout mode
-  if (currentStep !== 3 || presentation !== 'cutout') {
+): {
+  shouldReset: boolean;
+  defaultOffset: number | undefined;
+  defaultThickness: number | undefined;
+} {
+  // Only run when we're actually on step 3 (use displayed step to avoid race when navigating back)
+  if (currentStep !== 3) {
     return { shouldReset: false, defaultOffset: undefined, defaultThickness: undefined };
   }
 
-  const defaultOffset = selectedFlag?.modes?.cutout?.defaultOffset;
-  const defaultThickness = selectedFlag?.modes?.cutout?.defaultBorderThickness;
   const flagChanged = configuredForFlagId !== null && configuredForFlagId !== flagId;
   const firstTimeConfiguring = configuredForFlagId === null;
 
-  // Reset if flag changed or first time configuring
-  if (flagChanged || firstTimeConfiguring) {
-    return {
-      shouldReset: true,
-      defaultOffset: defaultOffset ?? 0, // Default to 0 if flag has no cutout config
-      defaultThickness,
-    };
+  if (!flagChanged && !firstTimeConfiguring) {
+    return { shouldReset: false, defaultOffset: undefined, defaultThickness: undefined };
   }
 
-  return { shouldReset: false, defaultOffset: undefined, defaultThickness: undefined };
+  // When in cutout mode, use cutout defaults; otherwise keep current values (pass undefined)
+  if (presentation === 'cutout') {
+    const defaultOffset = selectedFlag?.modes?.cutout?.defaultOffset ?? 0;
+    const defaultThickness = selectedFlag?.modes?.cutout?.defaultBorderThickness;
+    return { shouldReset: true, defaultOffset, defaultThickness };
+  }
+
+  // Ring/segment: still set configuredForFlagId and offset 0 so step3 is in sync; keep thickness
+  return { shouldReset: true, defaultOffset: 0, defaultThickness: undefined };
 }

--- a/src/pages/AppStepWorkflow.tsx
+++ b/src/pages/AppStepWorkflow.tsx
@@ -84,8 +84,10 @@ export function AppStepWorkflow() {
   }, [step2.flagId]);
 
   // Step transitions (handles flag offset resets, dimension detection, etc.)
+  // Pass displayed step (currentStep) so we never run step-3 logic while user is on step 2 after clicking Back
   useStepTransitions({
     state: workflow.state,
+    displayedStep: currentStep,
     selectedFlag,
     onImageDimensionsChange: setImageDimensions,
     onCircleSizeChange: setCircleSize,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1437,13 +1437,15 @@ label.choose-circle.has-image.is-dragging,
   flex-direction: column;
   align-items: center;
   gap: 20px;
+  padding-inline: 16px;
+  box-sizing: border-box;
 }
 
 .step-layout__controls {
   width: 100%;
   max-width: min(320px, 100%);
   min-width: 0;
-  padding-inline: 8px;
+  padding-inline: 16px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;

--- a/test/unit/hooks/useStepTransitions.test.ts
+++ b/test/unit/hooks/useStepTransitions.test.ts
@@ -74,6 +74,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: null,
         onImageDimensionsChange,
         onCircleSizeChange,
@@ -108,6 +109,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: null,
         onImageDimensionsChange,
         onCircleSizeChange: vi.fn(),
@@ -127,6 +129,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: null,
         onImageDimensionsChange: vi.fn(),
         onCircleSizeChange,
@@ -158,6 +161,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: mockFlag,
         onImageDimensionsChange: vi.fn(),
         onCircleSizeChange: vi.fn(),
@@ -167,7 +171,7 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(-50);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', -50);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', -50, undefined);
   });
 
   it('should reset offset when flag changes in cutout mode', () => {
@@ -190,6 +194,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: {
           ...mockFlag,
           id: 'venezuela',
@@ -208,7 +213,7 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(0);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('venezuela', 0);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('venezuela', 0, undefined);
   });
 
   it('should not change offset if flag has not changed', () => {
@@ -231,6 +236,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: mockFlag,
         onImageDimensionsChange: vi.fn(),
         onCircleSizeChange: vi.fn(),
@@ -263,6 +269,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: {
           id: 'no-cutout-flag',
           displayName: 'No Cutout',
@@ -275,10 +282,10 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(0);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('no-cutout-flag', 0);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('no-cutout-flag', 0, undefined);
   });
 
-  it('should not handle offset logic when not in cutout mode', () => {
+  it('should sync step3 when on step 3 in ring mode and first time configuring (keeps step3 in sync)', () => {
     const state = createState({
       currentStep: 3,
       step2: {
@@ -297,6 +304,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: mockFlag,
         onImageDimensionsChange: vi.fn(),
         onCircleSizeChange: vi.fn(),
@@ -305,8 +313,9 @@ describe('useStepTransitions', () => {
       }),
     );
 
-    expect(onFlagOffsetChange).not.toHaveBeenCalled();
-    expect(onUpdateStep3ForFlag).not.toHaveBeenCalled();
+    // We now sync step3 for any mode when flag not yet configured (fixes back-then-forward bug)
+    expect(onFlagOffsetChange).toHaveBeenCalledWith(0);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', 0, undefined);
   });
 
   it('should handle switching to cutout mode', () => {
@@ -328,6 +337,7 @@ describe('useStepTransitions', () => {
     renderHook(() =>
       useStepTransitions({
         state,
+        displayedStep: state.currentStep,
         selectedFlag: mockFlag,
         onImageDimensionsChange: vi.fn(),
         onCircleSizeChange: vi.fn(),
@@ -337,6 +347,6 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(-50);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', -50);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', -50, undefined);
   });
 });

--- a/test/unit/hooks/useWorkflowState.test.ts
+++ b/test/unit/hooks/useWorkflowState.test.ts
@@ -283,6 +283,22 @@ describe('workflowReducer', () => {
     expect(result.step3.configuredForFlagId).toBe('palestine');
     expect(result.step3.flagOffsetPct).toBe(25);
   });
+
+  it('should set step3.thickness when UPDATE_STEP3_FOR_FLAG has defaultThickness', () => {
+    const initialState = createInitialWorkflowState();
+    const action: WorkflowAction = {
+      type: 'UPDATE_STEP3_FOR_FLAG',
+      flagId: 'antifa-logo',
+      defaultOffset: 0,
+      defaultThickness: 13,
+    };
+
+    const result = workflowReducer(initialState, action);
+
+    expect(result.step3.configuredForFlagId).toBe('antifa-logo');
+    expect(result.step3.flagOffsetPct).toBe(0);
+    expect(result.step3.thickness).toBe(13);
+  });
 });
 
 describe('useWorkflowState', () => {

--- a/test/unit/hooks/workflowLogic.test.ts
+++ b/test/unit/hooks/workflowLogic.test.ts
@@ -20,9 +20,11 @@ describe('workflowLogic', () => {
       expect(result.shouldReset).toBe(false);
     });
 
-    it('should return false when not in cutout mode', () => {
+    it('should return true when on step 3 and first time configuring (any mode) so step3 stays in sync', () => {
       const result = shouldResetFlagOffset(3, 'ring', 'test-flag', null, mockFlag);
-      expect(result.shouldReset).toBe(false);
+      expect(result.shouldReset).toBe(true);
+      expect(result.defaultOffset).toBe(0);
+      expect(result.defaultThickness).toBeUndefined();
     });
 
     it('should return true when first time configuring', () => {

--- a/test/unit/hooks/workflowLogic.test.ts
+++ b/test/unit/hooks/workflowLogic.test.ts
@@ -48,5 +48,23 @@ describe('workflowLogic', () => {
       expect(result.shouldReset).toBe(true);
       expect(result.defaultOffset).toBe(0);
     });
+
+    it('should return defaultThickness when flag cutout has defaultBorderThickness', () => {
+      const flagWithThickness = {
+        ...mockFlag,
+        modes: { cutout: { defaultOffset: 25, defaultBorderThickness: 13 } },
+      } as FlagSpec;
+      const result = shouldResetFlagOffset(3, 'cutout', 'test-flag', null, flagWithThickness);
+      expect(result.shouldReset).toBe(true);
+      expect(result.defaultOffset).toBe(25);
+      expect(result.defaultThickness).toBe(13);
+    });
+
+    it('should return undefined defaultThickness when flag cutout has no defaultBorderThickness', () => {
+      const result = shouldResetFlagOffset(3, 'cutout', 'test-flag', null, mockFlag);
+      expect(result.shouldReset).toBe(true);
+      expect(result.defaultOffset).toBe(25);
+      expect(result.defaultThickness).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
feat(flags): default border thickness for cutout mode (issue 169) - Add defaultBorderThickness (5-15) to flag-data schema and YAML - Emit in typescript-generator; add to flags schema and Antifa in flags.ts - Workflow: shouldResetFlagOffset returns defaultThickness; reducer and onUpdateStep3ForFlag set step3.thickness when present - Unit tests: workflowLogic defaultThickness, reducer UPDATE_STEP3_FOR_FLAG

BUG FIX: Flags did not show when going back to step 2 from step 3
BUG FIX: No horizontal padding in main content area