### PR TITLE
fix(flags): apply cutout defaultBorderThickness on mode switch

### DIFF
--- a/src/hooks/useStepTransitions.ts
+++ b/src/hooks/useStepTransitions.ts
@@ -112,7 +112,7 @@ export function useStepTransitions(options: UseStepTransitionsOptions): void {
   // Handle flag offset and thickness reset logic (consolidated - handles both flag changes and mode switches)
   // Use displayedStep (from navigation) so we never run step-3 logic when user has clicked Back and is viewing step 2
   useEffect(() => {
-    const { shouldReset, defaultOffset, defaultThickness } = shouldResetFlagOffset(
+    const { shouldReset, configKey, defaultOffset, defaultThickness } = shouldResetFlagOffset(
       displayedStep,
       step3.presentation,
       step2.flagId,
@@ -122,7 +122,7 @@ export function useStepTransitions(options: UseStepTransitionsOptions): void {
 
     if (shouldReset) {
       onFlagOffsetChange(defaultOffset ?? 0);
-      onUpdateStep3ForFlag(step2.flagId, defaultOffset, defaultThickness);
+      onUpdateStep3ForFlag(configKey, defaultOffset, defaultThickness);
     }
   }, [
     displayedStep,

--- a/src/hooks/workflowLogic.ts
+++ b/src/hooks/workflowLogic.ts
@@ -12,7 +12,11 @@ import type { FlagSpec } from '@/flags/schema';
  *
  * Business rule: Sync when we're actually on step 3 and:
  * - Flag changed (user selected a different flag), or
+ * - Presentation mode changed (e.g. switched to cutout), or
  * - First time configuring (configuredForFlagId is null, e.g. after navigating back then forward).
+ *
+ * configuredForFlagId stores a composite key "flagId:mode" so that switching presentation mode
+ * also triggers re-application of mode-specific defaults (e.g. cutout defaultBorderThickness).
  *
  * Uses cutout defaults when in cutout mode; otherwise keeps current thickness/offset so we don't
  * overwrite user choices when switching flags in ring/segment mode.
@@ -25,28 +29,38 @@ export function shouldResetFlagOffset(
   selectedFlag: FlagSpec | null,
 ): {
   shouldReset: boolean;
+  configKey: string | null;
   defaultOffset: number | undefined;
   defaultThickness: number | undefined;
 } {
+  const noReset = {
+    shouldReset: false,
+    configKey: null,
+    defaultOffset: undefined,
+    defaultThickness: undefined,
+  };
+
   // Only run when we're actually on step 3 (use displayed step to avoid race when navigating back)
   if (currentStep !== 3) {
-    return { shouldReset: false, defaultOffset: undefined, defaultThickness: undefined };
+    return noReset;
   }
 
-  const flagChanged = configuredForFlagId !== null && configuredForFlagId !== flagId;
+  // Composite key tracks both flag and mode so switching either triggers a re-sync
+  const configKey = flagId ? `${flagId}:${presentation}` : null;
+  const configChanged = configuredForFlagId !== null && configuredForFlagId !== configKey;
   const firstTimeConfiguring = configuredForFlagId === null;
 
-  if (!flagChanged && !firstTimeConfiguring) {
-    return { shouldReset: false, defaultOffset: undefined, defaultThickness: undefined };
+  if (!configChanged && !firstTimeConfiguring) {
+    return noReset;
   }
 
   // When in cutout mode, use cutout defaults; otherwise keep current values (pass undefined)
   if (presentation === 'cutout') {
     const defaultOffset = selectedFlag?.modes?.cutout?.defaultOffset ?? 0;
     const defaultThickness = selectedFlag?.modes?.cutout?.defaultBorderThickness;
-    return { shouldReset: true, defaultOffset, defaultThickness };
+    return { shouldReset: true, configKey, defaultOffset, defaultThickness };
   }
 
   // Ring/segment: still set configuredForFlagId and offset 0 so step3 is in sync; keep thickness
-  return { shouldReset: true, defaultOffset: 0, defaultThickness: undefined };
+  return { shouldReset: true, configKey, defaultOffset: 0, defaultThickness: undefined };
 }

--- a/test/unit/hooks/useStepTransitions.test.ts
+++ b/test/unit/hooks/useStepTransitions.test.ts
@@ -171,7 +171,7 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(-50);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', -50, undefined);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine:cutout', -50, undefined);
   });
 
   it('should reset offset when flag changes in cutout mode', () => {
@@ -183,7 +183,7 @@ describe('useStepTransitions', () => {
       step3: {
         ...createInitialWorkflowState().step3,
         presentation: 'cutout',
-        configuredForFlagId: 'palestine', // Was configured for different flag
+        configuredForFlagId: 'palestine:cutout', // Was configured for different flag
         flagOffsetPct: -50,
       },
     });
@@ -213,10 +213,10 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(0);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('venezuela', 0, undefined);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('venezuela:cutout', 0, undefined);
   });
 
-  it('should not change offset if flag has not changed', () => {
+  it('should not change offset if flag and mode unchanged', () => {
     const state = createState({
       currentStep: 3,
       step2: {
@@ -225,7 +225,7 @@ describe('useStepTransitions', () => {
       step3: {
         ...createInitialWorkflowState().step3,
         presentation: 'cutout',
-        configuredForFlagId: 'palestine', // Already configured for this flag
+        configuredForFlagId: 'palestine:cutout', // Already configured for this flag+mode
         flagOffsetPct: -50,
       },
     });
@@ -245,7 +245,7 @@ describe('useStepTransitions', () => {
       }),
     );
 
-    // Should not be called since flag hasn't changed
+    // Should not be called since flag+mode hasn't changed
     expect(onFlagOffsetChange).not.toHaveBeenCalled();
     expect(onUpdateStep3ForFlag).not.toHaveBeenCalled();
   });
@@ -282,7 +282,7 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(0);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('no-cutout-flag', 0, undefined);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('no-cutout-flag:cutout', 0, undefined);
   });
 
   it('should sync step3 when on step 3 in ring mode and first time configuring (keeps step3 in sync)', () => {
@@ -315,7 +315,7 @@ describe('useStepTransitions', () => {
 
     // We now sync step3 for any mode when flag not yet configured (fixes back-then-forward bug)
     expect(onFlagOffsetChange).toHaveBeenCalledWith(0);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', 0, undefined);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine:ring', 0, undefined);
   });
 
   it('should handle switching to cutout mode', () => {
@@ -347,6 +347,50 @@ describe('useStepTransitions', () => {
     );
 
     expect(onFlagOffsetChange).toHaveBeenCalledWith(-50);
-    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine', -50, undefined);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine:cutout', -50, undefined);
+  });
+
+  it('should re-apply cutout defaults when switching from ring to cutout mode (fixes #169 hotfix)', () => {
+    const flagWithThickness = {
+      ...mockFlag,
+      modes: {
+        cutout: {
+          offsetEnabled: true,
+          defaultOffset: -50,
+          defaultBorderThickness: 13,
+        },
+      },
+    } as FlagSpec;
+
+    const state = createState({
+      currentStep: 3,
+      step2: {
+        flagId: 'palestine',
+      },
+      step3: {
+        ...createInitialWorkflowState().step3,
+        presentation: 'cutout', // User just switched to cutout
+        configuredForFlagId: 'palestine:ring', // Was configured for ring mode
+      },
+    });
+
+    const onFlagOffsetChange = vi.fn();
+    const onUpdateStep3ForFlag = vi.fn();
+
+    renderHook(() =>
+      useStepTransitions({
+        state,
+        displayedStep: state.currentStep,
+        selectedFlag: flagWithThickness,
+        onImageDimensionsChange: vi.fn(),
+        onCircleSizeChange: vi.fn(),
+        onFlagOffsetChange,
+        onUpdateStep3ForFlag,
+      }),
+    );
+
+    // Mode changed from ring→cutout, so cutout defaults should be applied
+    expect(onFlagOffsetChange).toHaveBeenCalledWith(-50);
+    expect(onUpdateStep3ForFlag).toHaveBeenCalledWith('palestine:cutout', -50, 13);
   });
 });

--- a/test/unit/hooks/workflowLogic.test.ts
+++ b/test/unit/hooks/workflowLogic.test.ts
@@ -25,23 +25,51 @@ describe('workflowLogic', () => {
       expect(result.shouldReset).toBe(true);
       expect(result.defaultOffset).toBe(0);
       expect(result.defaultThickness).toBeUndefined();
+      expect(result.configKey).toBe('test-flag:ring');
     });
 
     it('should return true when first time configuring', () => {
       const result = shouldResetFlagOffset(3, 'cutout', 'test-flag', null, mockFlag);
       expect(result.shouldReset).toBe(true);
       expect(result.defaultOffset).toBe(25);
+      expect(result.configKey).toBe('test-flag:cutout');
     });
 
     it('should return true when flag changed', () => {
-      const result = shouldResetFlagOffset(3, 'cutout', 'new-flag', 'old-flag', mockFlag);
+      const result = shouldResetFlagOffset(3, 'cutout', 'new-flag', 'old-flag:cutout', mockFlag);
       expect(result.shouldReset).toBe(true);
       expect(result.defaultOffset).toBe(25);
     });
 
-    it('should return false when flag unchanged', () => {
-      const result = shouldResetFlagOffset(3, 'cutout', 'test-flag', 'test-flag', mockFlag);
+    it('should return false when flag and mode unchanged', () => {
+      const result = shouldResetFlagOffset(3, 'cutout', 'test-flag', 'test-flag:cutout', mockFlag);
       expect(result.shouldReset).toBe(false);
+    });
+
+    it('should return true when mode changes from ring to cutout (same flag)', () => {
+      const flagWithThickness = {
+        ...mockFlag,
+        modes: { cutout: { defaultOffset: 25, defaultBorderThickness: 13 } },
+      } as FlagSpec;
+      const result = shouldResetFlagOffset(
+        3,
+        'cutout',
+        'test-flag',
+        'test-flag:ring',
+        flagWithThickness,
+      );
+      expect(result.shouldReset).toBe(true);
+      expect(result.defaultOffset).toBe(25);
+      expect(result.defaultThickness).toBe(13);
+      expect(result.configKey).toBe('test-flag:cutout');
+    });
+
+    it('should return true when mode changes from cutout to ring (same flag)', () => {
+      const result = shouldResetFlagOffset(3, 'ring', 'test-flag', 'test-flag:cutout', mockFlag);
+      expect(result.shouldReset).toBe(true);
+      expect(result.defaultOffset).toBe(0);
+      expect(result.defaultThickness).toBeUndefined();
+      expect(result.configKey).toBe('test-flag:ring');
     });
 
     it('should default to 0 when flag has no cutout config', () => {


### PR DESCRIPTION
Closes #185

## Summary
- **Bug**: `defaultBorderThickness` was never applied when switching from ring/segment to cutout mode on step 3, because `configuredForFlagId` only tracked the flag ID — not the presentation mode. Since the default mode is `ring`, by the time users switch to `cutout`, the flag is already "configured" and the cutout defaults get skipped.
- **Fix**: `configuredForFlagId` now stores a composite key (`flagId:mode`) so switching presentation mode also triggers re-application of mode-specific defaults.
- Adds targeted unit tests for the ring→cutout mode switch scenario.

## Root cause
`shouldResetFlagOffset` only re-applied defaults when the flag changed or on first configuration. The typical user flow (arrive at step 3 in ring mode → switch to cutout) meant the flag was marked as "configured" during ring mode, and the subsequent cutout switch was a no-op.

## Test plan
- [x] All 288 unit/integration tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] ESLint clean on source files
- [x] Prettier clean on all changed files
- [ ] Manual: select Bisexual flag → step 3 → switch to cutout → verify thickness is 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)