### PR TITLE
fix(ci): pre-commit ESLint filter and CI manual trigger

### DIFF
--- a/.github/scripts/pre-commit.ps1
+++ b/.github/scripts/pre-commit.ps1
@@ -55,8 +55,8 @@ if (-not $stagedFiles) {
     exit 0
 }
 
-# Filter for code files (for linting)
-$codeFiles = $stagedFiles | Where-Object { $_ -match '\.(ts|tsx|js|jsx)$' }
+# Filter for code files that ESLint is configured to handle (src/ only)
+$codeFiles = $stagedFiles | Where-Object { $_ -match '^src/.*\.(ts|tsx|js|jsx)$' }
 
 # Filter for all Prettier-supported files (for formatting)
 $prettierFiles = $stagedFiles | Where-Object { $_ -match '\.(ts|tsx|js|jsx|md|yml|yaml|json)$' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'feature/**'
@@ -50,7 +51,7 @@ jobs:
   # Lightweight validation (security, markdown, yaml, etc.) - runs in parallel with build-and-test
   validate:
     needs: check-changes
-    if: needs.check-changes.outputs.production-code == 'true'
+    if: needs.check-changes.outputs.production-code == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -103,7 +104,7 @@ jobs:
   # Lint, format, build, unit tests - runs first for fastest feedback (most common failures)
   build-and-test:
     needs: check-changes
-    if: needs.check-changes.outputs.production-code == 'true'
+    if: needs.check-changes.outputs.production-code == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -152,7 +153,7 @@ jobs:
   # E2E tests (full suite, all browsers) - after unit tests pass
   e2e:
     needs: [check-changes, build-and-test]
-    if: needs.check-changes.outputs.production-code == 'true'
+    if: needs.check-changes.outputs.production-code == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #184
Closes #168

## Summary
- **Pre-commit hook (#184)**: ESLint check now only lints `src/` files, matching the ESLint flat config scope. Previously, staging test files caused false "Linting failed" errors because ESLint has no config for `test/`.
- **CI manual trigger (#168)**: Added `workflow_dispatch` to the CI workflow so it can be triggered manually from the GitHub Actions UI. All jobs (validate, build-and-test, e2e) bypass the paths-filter gate on manual dispatch.

`package.json` was already in the `dorny/paths-filter` production-code list, so it already triggers CI on push — no change needed there.

## Test plan
- [x] All 288 unit/integration tests pass
- [ ] Stage a test file → `git commit` → pre-commit passes ESLint
- [ ] Push branch → CI runs normally
- [ ] Check GitHub Actions UI for "Run workflow" button on CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)