### PR TITLE
fix(flags): disable offset slider for Antifa logo (square, no effect)

### DIFF
--- a/data/flag-data.yaml
+++ b/data/flag-data.yaml
@@ -378,7 +378,10 @@ categories:
           - url: 'https://www.hrw.org/topic/free-speech'
             text: 'Human Rights Watch: Free speech'
         cutoutMode:
-          offsetEnabled: true
+          # Logo is a perfectly square image (1365x1365), so horizontal offset has no visual
+          # effect (flagExtension = max(0, width-height)/2 = 0 for a 1:1 aspect ratio) - the
+          # only flag in the dataset where this applies.
+          offsetEnabled: false
           defaultOffset: 0
           defaultBorderThickness: 13
 

--- a/src/flags/flags.ts
+++ b/src/flags/flags.ts
@@ -881,7 +881,7 @@ export const flags: FlagSpec[] = [
         colors: ['#000000', '#ffffff', '#ff0000'],
       },
       cutout: {
-        offsetEnabled: true,
+        offsetEnabled: false,
         defaultOffset: 0,
         defaultBorderThickness: 13,
       },


### PR DESCRIPTION
## Summary

Found while testing the WebGL PR (#189), but confirmed unrelated to it - this branch never touches `src/flags/`, `data/flag-data.yaml`, or `AdjustControls.tsx`.

Selecting the Antifa flag in cutout mode leaves the flag-offset slider enabled on Step 3, but adjusting it has no visual effect. Root cause: the logo image is a perfectly square PNG (1365x1365). The cutout renderer's flag-offset math only does anything when the flag rect's width and height differ (`flagExtension = max(0, flagRectWidth - flagRectHeight) / 2`), which is always 0 at a 1:1 aspect ratio.

`offsetEnabled` is a static per-flag YAML field (not computed from the actual image), and it turns out **every flag in the dataset has `offsetEnabled: true`** - Antifa is the only square-aspect flag, so this is the only place it was ever actually wrong.

## Changes

- `data/flag-data.yaml`: `offsetEnabled: false` for Antifa's `cutoutMode`, with a comment explaining why
- `src/flags/flags.ts`: hand-edited to match (didn't run `fetch-flags.js` - it re-fetches/re-rasterizes every flag's source SVG over the network, which produced an unrelated diff across 12 other flags' PNGs plus formatting drift between the script's current output and what's committed; out of scope for a one-line data fix)

## Test plan

- [x] Typecheck, lint, format all pass
- [x] `flags.test.ts` / `schema.test.ts` pass
- [ ] CI green