### PR TITLE
fix(ci): make CI and branch-naming actually run on Dependabot PRs

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Check branch name
         run: |
           BRANCH="${{ github.head_ref || github.ref_name }}"
-          # Allow main, gh-pages, and feature/feat/fix/etc prefixes
-          if echo "$BRANCH" | grep -qE '^(main|gh-pages)$|^(feature|feat|fix|hotfix|refactor|test|docs|style|perf|chore|ci)/'; then
+          # Allow main, gh-pages, feature/feat/fix/etc prefixes, and Dependabot's own naming
+          if echo "$BRANCH" | grep -qE '^(main|gh-pages)$|^(feature|feat|fix|hotfix|refactor|test|docs|style|perf|chore|ci|dependabot)/'; then
             echo "✅ Branch name OK: $BRANCH"
             exit 0
           fi
-          echo "::error::Branch name must match: main, gh-pages, or (feature|feat|fix|hotfix|refactor|test|docs|style|perf|chore|ci)/<name>"
+          echo "::error::Branch name must match: main, gh-pages, or (feature|feat|fix|hotfix|refactor|test|docs|style|perf|chore|ci|dependabot)/<name>"
           echo "Current branch: $BRANCH"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - 'perf/**'
       - 'chore/**'
       - 'ci/**'
+      - 'dependabot/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

None of the 12 currently-open Dependabot PRs (#200-#222) can pass CI - `ci.yml`'s `push` trigger only matches a fixed list of human branch-name prefixes (`feature/**`, `fix/**`, etc.), so it never runs at all on `dependabot/npm_and_yarn/*` or `dependabot/github_actions/*` branches. The required `build-and-test` check sits permanently absent (not failing - never triggered), which blocks merge indefinitely. `branch-naming.yml` has the same gap and fails outright on every Dependabot PR (not a required check, but a persistent false-positive red X).

Fix: add `dependabot/**` to both workflows' branch patterns.

## Test plan

- [ ] This PR's own branch (`fix/**`) runs CI normally (proves the syntax is valid and nothing else broke)
- [ ] After merge, `@dependabot rebase` on an open Dependabot PR triggers a real `build-and-test` run